### PR TITLE
[examples] Add some example templefiles

### DIFF
--- a/TempleEight/docs/reference/example-templefiles/airbnb.md
+++ b/TempleEight/docs/reference/example-templefiles/airbnb.md
@@ -3,3 +3,64 @@ id: airbnb
 title: Airbnb
 sidebar_label: Airbnb
 ---
+
+The following Templefile captures Airbnb's core model, the online marketplace for arranging and offering lodging.
+
+```
+Airbnb: project {
+  #language(go);
+  #database(postgres);
+  #authMethod(email);
+  #provider(dockerCompose);
+  #metrics(prometheus);
+}
+
+// Since the project has auth, #readable and #writable for all services default to (by: this)
+
+Landlord: service {
+  firstName: string;
+  lastName: string;
+  #auth;
+  #readable(by: all);
+}
+
+Tenant: service {
+  firstName: string;
+  lastName: string;
+  #auth;
+}
+
+Property: service {
+  landlord: Landlord;
+  address: string;
+  city: string;
+  postcode: string;
+  description: string;
+  pricePerNight: float;
+
+  Photo: struct {
+    image: data(5M);
+    caption: string;
+    #enumerable;
+  }
+
+  #enumerable;
+  #readable(by: all);
+}
+
+Reservation: service {
+  tenant: Tenant;
+  property: Property;
+  startTime: datetime;
+  endTime: datetime;
+}
+
+Review: service {
+  property: Property;
+  tenant: Tenant;
+  reservation: Reservation;
+  stars: int(5, 0);
+  review: string;
+  #readable(by: all);
+}
+```

--- a/TempleEight/docs/reference/example-templefiles/amazon.md
+++ b/TempleEight/docs/reference/example-templefiles/amazon.md
@@ -1,0 +1,73 @@
+---
+id: amazon
+title: Amazon
+sidebar_label: Amazon
+---
+
+The following Templefile captures Amazon's core e-commerce model, the online marketplace for goods.
+
+```
+Amazon: project {
+  #language(go);
+  #database(postgres);
+  #authMethod(email);
+  #provider(dockerCompose);
+}
+
+// Since the project has auth, #readable and #writable for all services default to (by: this)
+
+Seller: service {
+  firstName: string;
+  lastName: string;
+  #auth;
+  #enumerable;
+  #readable(by: all);
+}
+
+Customer: service {
+  firstName: string;
+  lastName: string;
+  addressLine1: string;
+  addressLine2: string;
+  town: string;
+  county: string;
+  postcode: string;
+  #auth;
+}
+
+ProductCategory: service {
+  name: string;
+  #enumerable;
+  #readable(by: all);
+}
+
+Product: service {
+  category: ProductCategory;
+  seller: Seller;
+  name: string;
+  description: string;
+  price: float;
+
+  Picture: struct {
+    image: data(5M);
+    #enumerable;
+  }
+
+  #enumerable;
+  #readable(by: all);
+}
+
+Order: service {
+  customer: Customer;
+  orderDate: datetime;
+
+  // OrderItem is a join table between Orders and Products (many to many)
+  OrderItem: struct {
+    product: Product;
+    #enumerable;
+  }
+
+  #omit[delete];
+  #enumerable;
+}
+```

--- a/TempleEight/docs/reference/example-templefiles/deliveroo.md
+++ b/TempleEight/docs/reference/example-templefiles/deliveroo.md
@@ -1,0 +1,90 @@
+---
+id: deliveroo
+title: Deliveroo
+sidebar_label: Deliveroo
+---
+
+The following Templefile captures Deliveroo's core model, the food delivery service.
+
+```
+Deliveroo: project {
+  #language(go);
+  #database(postgres);
+  #authMethod(email);
+  #provider(dockerCompose);
+  #metrics(prometheus);
+}
+
+// Since the project has auth, #readable and #writable for all services default to (by: this)
+
+// Users order dishes, paid for with their billing account
+User: service {
+  firstName: string;
+  lastName: string;
+  email: string;
+  address: string;
+  billingAccount: Billing;
+  #auth;
+}
+
+// Riders deliver orders, location included for the user to know where they are
+Rider: service {
+  firstName: string;
+  lat: float(90.0, -90.0);
+  long: float(180.0, -180.0);
+  #auth;
+}
+
+// Restaurants make dishes to be picked up by riders
+Restaurant: service {
+  name: string;
+  address: string;
+  openTime: time;
+  closeTime: time;
+  #auth;
+  #enumerable;
+  #readable(by: all);
+}
+
+// An order marks a dish to be delivered by a rider from a restaurant to a user
+Order: service {
+  user: User;
+  restaurant: Restaurant;
+  rider: Rider;
+  address: string;
+  orderTime: datetime @serverSet;
+  status: string;
+
+  // An order can have many dishes
+  OrderItem: struct {
+      dish: Dish;
+      #enumerable;
+  }
+
+  #omit[delete];
+  #enumerable;
+}
+
+// A dish is made by a restaurant and is delivered to a user
+Dish: service {
+  name: string;
+  description: string;
+  price: float(0.0);
+  restaurant: Restaurant;
+
+  Img: struct {
+      img: data(4M);
+      #enumerable;
+  }
+  
+  #enumerable;
+  #readable(by: all)
+}
+
+// A billing account for a user, kept separately for security
+Billing: service {
+  creditCard: string(16,16); // creditCards must be exactly 16 chars long
+  expiry: date;
+  billingAddress: string;
+}
+```

--- a/TempleEight/docs/reference/example-templefiles/five-a-side.md
+++ b/TempleEight/docs/reference/example-templefiles/five-a-side.md
@@ -1,0 +1,62 @@
+---
+id: five-a-side
+title: 5-a-Side
+sidebar_label: 5-a-Side
+---
+
+The following Templefile is for a small sports company, that wants to provide their customers with a system for booking themselves onto 5-a-side football games. This could be extended to also provide a league/tournament system.
+
+```
+FiveASide: project {
+  #language(go);
+  #database(postgres);
+  #authMethod(email);
+  #provider(dockerCompose);
+}
+
+// Since the project has auth, #readable and #writable for all services default to (by: this)
+
+Staff: service {
+  firstName: string;
+  lastName: string;
+  email: string;
+  #auth;
+}
+
+Player: service {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: int;
+  #auth;
+}
+
+EmergencyContact: service {
+  player: Player;
+  firstname: string;
+  lastName: string;
+  relation: string;
+  email: string;
+  phoneNumber: int;
+  #readable(by: all); // Enforce only readable by the relevant player and staff in beforeRead hook
+}
+
+Game: service {
+  pitchNumber: int;
+  price: float;
+  maxPlayers: int;
+  start: datetime;
+  end: datetime;
+  #enumerable;
+  #readable(by: all);
+  // Enforce only creatable by staff in the beforeCreate hook
+}
+
+Booking: service {
+  player: Player;
+  game: Game;
+  #enumerable;
+  #readable(by: all);
+  // Enforce only creatable if game max players has not been reached in beforeCreate hook
+}
+```

--- a/TempleEight/docs/reference/example-templefiles/lockdown-shopping.md
+++ b/TempleEight/docs/reference/example-templefiles/lockdown-shopping.md
@@ -1,0 +1,92 @@
+---
+id: lockdown-shopping
+title: Lockdown Shopping
+sidebar_label: Lockdown Shopping
+---
+
+The following Templefile is for a system that would allow those who are self-isolating to request others in the community to deliver shopping to their doorstep.
+
+
+```
+LockdownShopping: project {
+   #language(go);
+   #database(postgres);
+   #authMethod(email);
+   #provider(dockerCompose);
+   #metrics(prometheus);
+}
+
+// Since the project has auth, #readable and #writable for all services default to (by: this)
+
+// Shoppers take Customer's orders and deliver them to their houses
+Shopper: service {
+  firstName: string;
+  lastName: string;
+  #auth;
+  #readable(by: all);
+  
+}
+
+// Customers place orders for Shoppers to deliver
+Customer: service {
+  firstName: string;
+  lastName: string;
+
+  addressLine1: string;
+  addressLine2: string;
+  town: string;
+  county: string;
+  postcode: string;
+
+  #auth;
+  #readable(by: all);
+}
+
+Shop: service {
+  name: string;
+
+  address: string;
+  addressLine2: string;
+  town: string;
+  county: string;
+  postcode: string;
+
+  #auth;
+  #enumerable;
+  #readable(by: all);
+}
+
+// Products are items that can be purchased from a Shop
+Product: service {
+  name: string;
+  price: float;
+  shop: Shop;
+
+  Picture: struct {
+    image: data(5M);
+    #enumerable;
+  }
+
+  #enumerable;
+  #readable(by: all);
+  // Enforce only creatable by the relevant shop in the beforeCreate hook
+}
+
+// An order contains a series of items associated with a given customer on a given date
+Order: service {
+  customer: Customer;
+  orderDate: date;
+  fulfilled: bool;
+  requestedDeliveryDate: date;
+
+  // OrderItem is a join table between Orders and Products (many to many)
+  OrderItem: struct {
+    product: Product;
+    #enumerable;
+  }
+
+  #omit[delete];
+  #enumerable;
+  #readable(by: all);
+}
+```

--- a/TempleEight/sidebars.js
+++ b/TempleEight/sidebars.js
@@ -45,6 +45,10 @@ module.exports = {
           label: 'Example Templefiles',
           items: [
             'reference/example-templefiles/airbnb',
+            'reference/example-templefiles/amazon',
+            'reference/example-templefiles/deliveroo',
+            'reference/example-templefiles/five-a-side',
+            'reference/example-templefiles/lockdown-shopping',
           ]
         }
       ]


### PR DESCRIPTION
* Adds the example templefiles we designed from the main temple repo
  * Tidies them up for documentation: makes formatting the same between them, order of metadata tags, removes TODOs, adds comments where relevant, etc.

The Deliveroo example had some incorrect `#readable` and `#writable` tags, not taking into the project default. The `Rider` service has location fields for the user to know where they are, but the `Rider` service is `#readable(by: this)`, since the project has auth. Needs checking over by the author.